### PR TITLE
Fix CONTRIBUTING.md heading syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,11 @@ Com npm instalado, rode no terminal:
 $ npm start
 ```
 
-#Como se adicionar no .json
-##Gravatar: https://en.gravatar.com/
+# Como se adicionar no .json
+## Gravatar: https://en.gravatar.com/
 Para adicionar uma photo ao seu card, crie uma conta e faça upload do seu avatar no gravatar ou use a sua conta já existente.
 
-##Campos do .json dissecados
+## Campos do .json dissecados
 Em **linkedin**, **github**, **twitter** e **fb**: usar apenas o username da url da rede social.
 
 **Exemplo:**
@@ -19,7 +19,7 @@ https://br.linkedin.com/in/foob >> "foob"
 
 etc
 
-**Evite muitas tags em "interests"** 
+**Evite muitas tags em "interests"**
 
 Dependendo do tamanho, cabem até 7 no card da página, mas o ideal seria usar **4** tags no **máximo**.
 ```


### PR DESCRIPTION
Haviam alguns headings com a sintaxe quebrada:

## Antes:
![image](https://user-images.githubusercontent.com/2192462/27796635-19ece13e-5fe1-11e7-92f9-82814e7aa8e5.png)

## Depois:
![image](https://user-images.githubusercontent.com/2192462/27796666-35ebe542-5fe1-11e7-8095-ea010f7030e8.png)
